### PR TITLE
Filtersets V2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "entrace_core",
+ "itertools",
  "memchr",
  "mlua",
  "roaring",
@@ -2089,6 +2090,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"

--- a/docs/filtersets.md
+++ b/docs/filtersets.md
@@ -1,10 +1,11 @@
-THE FILTERSET CALCULUS
+THE FILTERSET CALCULUS (v2)
 ---
 
 ### TYPES
 
 ```rust
 type FiltersetId = usize;
+type PreidcateId = usize;
 struct Predicate {
     attr: String,
     rel: Ordering,
@@ -14,9 +15,8 @@ struct Predicate {
 enum Filterset {
     Dead,
     Primitive(Roaring),
-    Rel(Predicate, FiltersetId),
-    RelIntersect(Vec<Predicate>, FiltersetId),
-    RelUnion(Vec<Predicate>, FiltersetId),
+    BlackBox(FiltersetId),
+    RelDnf(Vec<Vec<PredicateId>>, FiltersetId),
     And(Vec<FiltersetId>),
     Or(Vec<FiltersetId>),
     Not(FiltersetId),
@@ -30,25 +30,12 @@ enum Filterset {
 And([... And(children) ...]) -> And(flattened)
 Or([... Or(children) ...])  -> Or(flattened)
 Not(Not(X)) -> X
-
-**Eliminating trivial ops (unimplemeneted)**
 And([A]) -> A
 Or([A]) -> A
 
-**REL composition**
+**One Rule To Rule Them All**
+1. RelDnf(clauses, RelDnf(clauses2, A)) -> new clauses: c_1 \times c_2 (if the result won't be too big)
 
-I.   Rel(p1, Rel(p2, A)) -> RelIntersect([p1, p2], A)
-II.  Rel(p, RelIntersect(ps, A)) -> RelIntersect([p] + ps, A)
-III. RelIntersect(ps1, RelIntersect(ps2, A)) -> RelIntersect(ps1 + ps2, A)
-IV.  RelIntersect(ps, Rel(p, A)) -> RelIntersect(ps + [p], A)
-V.   RelUnion(ps1, RelUnion(ps2, A)) -> RelUnion(ps1 + ps2, A)
-
-
-**Flattening on the same level (unimplemeneted)**
-And([RelIntersect(ps, A), RelIntersect(ps2, A), RelIntersect(_, B) ...])
-  -> And([RelIntersect(ps1+ps2, A), RelIntersect(_, B)])
-    - This could be hard to detect, instead there could be just:
-      And([RelIntersect(ps_1, A), .. RelIntersect(ps_n, A)]) -> RelIntersect(ps_1+..+ps_n, A)
-Or([RelUnion(ps, A), RelUnion(ps2, A), RelUnion(_, B) ...])
-    -> Or([RelUnion(ps1+ps2, A), RelIntersect(_, B)])
-    - same applies here.
+**RelDnf in Or/And**
+1. Or([RelDnf(c, A), RelDnf(c2, A), RelDnf(c3, B), RelDnf(c4, B)]) -> Or([RelDnf(c+c2, A), RelDnf(c3+c4, B)])
+2. And([RelDnf(c, A), RelDnf(c2, A), RelDnf(c3, B), RelDnf(c4, B)]) -> And([RelDnf(c x c2, A), RelDnf(c3 x c4, B)]) (if not too big)

--- a/entrace_core/src/log_provider.rs
+++ b/entrace_core/src/log_provider.rs
@@ -35,7 +35,8 @@ pub trait LogProvider {
     /// This MUST be cheap as the frontend might call this every frame.
     fn len(&self) -> usize;
 
-    /// The frontent SHOULD call this at the beginning of each painted frame.
+    /// The frontent SHOULD call this at the beginning of each painted frame,
+    /// but there is no guarantee to whether or when it will.
     /// This runs on the main thread.
     /// The [LogProvider] implementation MUST ensure that this terminates quickly,
     /// as it directly affects FPS.

--- a/entrace_query/Cargo.toml
+++ b/entrace_query/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.100"
 memchr = "2.7.6"
 thiserror = "2.0.17"
 roaring = "0.11.2"
+itertools = "0.14.0"
 
 [[bin]]
 name="entrace-query-test"

--- a/entrace_query/src/main.rs
+++ b/entrace_query/src/main.rs
@@ -1,29 +1,25 @@
 use std::cmp::Ordering;
 
 use entrace_core::EnValue;
-use entrace_query::filtersets::{Evaluator, Filterset, Predicate, YesManMatcher};
+use entrace_query::filtersets::{Evaluator, Filterset, Predicate};
 use roaring::RoaringBitmap as Roaring;
 fn main() {
     // Motivating example: filter people with (180<height<195 and 75<weight<90) or (iq == 120)
-    let mut evaluator = Evaluator::<YesManMatcher, EnValue>::from_matcher(YesManMatcher());
-    evaluator.pool.push(Filterset::Primitive(Roaring::full()));
-    evaluator
-        .pool
-        .push(Filterset::Rel(Predicate::new("height", Ordering::Greater, EnValue::U64(180)), 0));
-    evaluator
-        .pool
-        .push(Filterset::Rel(Predicate::new("height", Ordering::Less, EnValue::U64(195)), 1));
-    evaluator
-        .pool
-        .push(Filterset::Rel(Predicate::new("weight", Ordering::Greater, EnValue::U64(75)), 2));
-    evaluator
-        .pool
-        .push(Filterset::Rel(Predicate::new("weight", Ordering::Less, EnValue::U64(90)), 3));
-    evaluator
-        .pool
-        .push(Filterset::Rel(Predicate::new("iq", Ordering::Equal, EnValue::U64(120)), 0));
-    evaluator.pool.push(Filterset::Or(vec![4, 5]));
-    println!("Before:\n{}", evaluator.dot(6));
-    evaluator.normalize(6);
-    println!("After:\n{}", evaluator.dot(6));
+    let mut evaluator = Evaluator::<EnValue>::new();
+    use EnValue::*;
+    use Ordering::*;
+    let src = evaluator.new_filterset(Filterset::Primitive(Roaring::full()));
+    let height_lower =
+        evaluator.new_dnf(vec![vec![Predicate::new("height", Greater, U64(180))]], src);
+    let height_upper = evaluator.new_dnf(vec![vec![Predicate::new("height", Less, U64(195))]], src);
+    let height_and = evaluator.new_filterset(Filterset::And(vec![height_lower, height_upper]));
+    let weight_lower =
+        evaluator.new_dnf(vec![vec![Predicate::new("weight", Greater, U64(75))]], height_and);
+    let weight_upper =
+        evaluator.new_dnf(vec![vec![Predicate::new("weight", Less, U64(90))]], weight_lower);
+    let iq = evaluator.new_dnf(vec![vec![Predicate::new("iq", Equal, U64(120))]], 0);
+    let or = evaluator.new_filterset(Filterset::Or(vec![weight_upper, iq]));
+    println!("Before:\n{}", evaluator.dot(or));
+    evaluator.normalize(or);
+    println!("After:\n{}", evaluator.dot(or));
 }

--- a/entrace_script/test_script.lua
+++ b/entrace_script/test_script.lua
@@ -6,4 +6,11 @@ local message_matches = en_filter(msg_filter_desc, base)
 
 breadth_filter_desc = { target = "breadth", value = 1, relation = "GT" }
 local breadth_matches = en_filter(breadth_filter_desc, base)
-print(en_pretty_table(breadth_matches))
+
+both_matches = en_filterset_dnf({
+	{
+		{ target = "breadth", value = 1,                  relation = "GT" },
+		{ target = "message", value = "constructed node", relation = "EQ" }
+	}
+}, base)
+print(en_pretty_table(both_matches))


### PR DESCRIPTION
Simplifies filtersets. 
The primary filter type is now a RelDnf (the ids of spans matching a Disjunctive Normal Form over a source). This makes rewrite rules simpler (many -> one (intersection of DNFS)), and also results in better performance, since we can merge many kinds of nodes into one DNF, which corresponds to only a single scan on the data.

This is older work, but I forgot to push it.